### PR TITLE
Added functionality to decimal export for precision and size.

### DIFF
--- a/lib/ModelExport.coffee
+++ b/lib/ModelExport.coffee
@@ -128,7 +128,10 @@ module.exports = (() ->
               typeOutStr += if length then length else ''
 
               if field.Type.match('unsigned')
-                typeOutStr += '.UNSIGNED'
+                typeOutStr += '.UNSIGNED'            
+            else if type.value is 'DECIMAL'
+              length = field.Type.match(/\(\d+,\d+\)/)
+              typeOutStr += if length then length else ''
 
         if type is 'coffee'
           if exportDefaultValue is true

--- a/lib/ModelExport.coffee
+++ b/lib/ModelExport.coffee
@@ -132,6 +132,9 @@ module.exports = (() ->
             else if type.value is 'DECIMAL'
               length = field.Type.match(/\(\d+,\d+\)/)
               typeOutStr += if length then length else ''
+            else if type.value is 'ENUM'
+              length = field.Type.match(/\(.*\)/)
+              typeOutStr += if length then length else ''
 
         if type is 'coffee'
           if exportDefaultValue is true


### PR DESCRIPTION
When using sequelize to import with the DB objects created by the export the decimal would default to DECIMAL(10,0) and have no precision for decimal places.  This will fix the export of the decimal object to export DECIMAL(9,2) rather than just DECIMAL.  DECIMAL(9,2) is just an example of the use case required for precision.